### PR TITLE
Improvements and bug fixes, bump to v0.2.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,8 @@ It's a work in progress with a learning curve, but we've already used it to crea
 ### 0.2.3
 
 * Fix broken pink to print stylesheets.
-* Add font includes: Oswald.
+* Fix broken links in @font-face partials.
+* Add more font includes.
 
 ### 0.2.2
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,11 @@ It's a work in progress with a learning curve, but we've already used it to crea
 
 ## Changelog
 
+### 0.2.3
+
+* Fix broken pink to print stylesheets.
+* Add font includes: Oswald.
+
 ### 0.2.2
 
 * Improve navigation layout.

--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ It's a work in progress with a learning curve, but we've already used it to crea
 * Fix broken pink to print stylesheets.
 * Fix broken links in @font-face partials.
 * Add more font includes.
+* Turn on kramdown auto_id_stripping to keep IDs neat and persistent, and ahead of 2.0 where this will be default.
+* Fix line-height on chapter-numbers to retain baseline grid.
 
 ### 0.2.2
 

--- a/_config.yml
+++ b/_config.yml
@@ -90,6 +90,12 @@ url: http://localhost:4000
 # Leave this unchanged as kramdown unless you really know how and why to change your markdown processor
 markdown: kramdown
 
+# kramdown options (see http://kramdown.gettalong.org/options.html)
+# auto_id_stripping remove formatting from headings before generating IDs
+# which keeps your IDs neat and tidy, and links persistent even if you format headings
+kramdown:
+  auto_id_stripping: true;
+
 # Leave this unchanged as none. This way, your book's chapters will all generate correctly named in one folder.
 # This is really useful for grabbing all your HTML files at once for including in epubs or sending to PrinceXML.
 permalink: none

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -40,8 +40,8 @@
     <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="stylesheet" type="text/css" media="screen" href="{{ site.baseurl }}/_themes/{{ site.theme }}/css/{{ page.stylesheet-web }}" />
-    <link rel="stylesheet" type="text/css" media="print" href="{{ site.baseurl }}/_themes/{{ site.theme }}/css/{{ page.stylesheet-print }}" />
-    <link rel="stylesheet" type="text/css" media="print" href="{{ site.baseurl }}/_themes/{{ site.theme }}/css/mods/print-no-bleed.css" />
+    <link rel="stylesheet" type="text/css" media="print" href="../_themes/{{ site.theme }}/css/{{ page.stylesheet-print }}" />
+    <link rel="stylesheet" type="text/css" media="print" href="../_themes/{{ site.theme }}/css/mods/print-no-bleed.css" />
 </head>
 <body class="{{ page.style }}">
 
@@ -59,7 +59,7 @@
     <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="stylesheet" type="text/css" media="screen" href="{{ site.baseurl }}/_themes/{{ site.theme }}/css/{{ page.stylesheet-web }}" />
-    <link rel="stylesheet" type="text/css" media="print" href="{{ site.baseurl }}/_themes/{{ site.theme }}/css/{{ page.stylesheet-print }}" />
+    <link rel="stylesheet" type="text/css" media="print" href="../_themes/{{ site.theme }}/css/{{ page.stylesheet-print }}" />
 
     <!-- Google Analytics, runs unless this is running through PrinceXML -->
     <script>

--- a/_themes/classic/css/_sass/partials/_print-base-typography.scss
+++ b/_themes/classic/css/_sass/partials/_print-base-typography.scss
@@ -22,9 +22,10 @@ h1 {
 	line-height: $line-height-default * 3;
 	margin: 0 0 ($line-height-default * 3) 0;
 }
-h1 strong:first-of-type { /* Useful for chapter numbers: make the number first and bold in the h1 */
+h1 strong:first-of-type { // Useful for chapter numbers: make the number first and bold in the h1
 	display: block;
 	margin: 0 0 $line-height-default 0;
+	line-height: inherit;
 }
 h2 {
 	font-size: $font-size-default * 2;

--- a/_themes/classic/css/_sass/partials/fonts/_adobe-caslon-pro.scss
+++ b/_themes/classic/css/_sass/partials/fonts/_adobe-caslon-pro.scss
@@ -1,32 +1,32 @@
 // Adobe Caslon Pro
 @font-face {
     font-family: "Adobe Caslon Pro";
-    src: url(fonts/ACaslonPro-Regular.otf);
+    src: url(../fonts/ACaslonPro-Regular.otf);
 }
 @font-face {
     font-family: "Adobe Caslon Pro";
-    src: url(fonts/ACaslonPro-Bold.otf);
+    src: url(../fonts/ACaslonPro-Bold.otf);
 	font-weight: bold;
 }
 @font-face {
     font-family: "Adobe Caslon Pro";
-    src: url(fonts/ACaslonPro-Italic.otf);
+    src: url(../fonts/ACaslonPro-Italic.otf);
 	font-style: italic;
 }
 @font-face {
     font-family: "Adobe Caslon Pro";
-    src: url(fonts/ACaslonPro-BoldItalic.otf);
+    src: url(../fonts/ACaslonPro-BoldItalic.otf);
 	font-weight: bold;
 	font-style: italic;
 }
 @font-face {
     font-family: "Adobe Caslon Pro";
-    src: url(fonts/ACaslonPro-Semibold.otf);
+    src: url(../fonts/ACaslonPro-Semibold.otf);
     font-weight: 600;
 }
 @font-face {
     font-family: "Adobe Caslon Pro";
-    src: url(fonts/ACaslonPro-SemiboldItalic.otf);
+    src: url(../fonts/ACaslonPro-SemiboldItalic.otf);
     font-weight: 600;
     font-style: italic;
 }

--- a/_themes/classic/css/_sass/partials/fonts/_cormorant-garamond.scss
+++ b/_themes/classic/css/_sass/partials/fonts/_cormorant-garamond.scss
@@ -1,56 +1,56 @@
 // Cormorant Garamond https://www.google.com/fonts/specimen/Cormorant
 @font-face {
     font-family: "Cormorant Garamond";
-    src: url(fonts/CormorantGaramond-Light.ttf);
+    src: url(../fonts/CormorantGaramond-Light.ttf);
     font-weight: 300;
 }
 @font-face {
     font-family: "Cormorant Garamond";
-    src: url(fonts/CormorantGaramond-LightItalic.ttf);
+    src: url(../fonts/CormorantGaramond-LightItalic.ttf);
     font-weight: 300;
     font-style: italic;
 }
 @font-face {
     font-family: "Cormorant Garamond";
-    src: url(fonts/CormorantGaramond-Regular.ttf);
+    src: url(../fonts/CormorantGaramond-Regular.ttf);
     font-weight: 400;
 }
 @font-face {
     font-family: "Cormorant Garamond";
-    src: url(fonts/CormorantGaramond-Italic.ttf);
+    src: url(../fonts/CormorantGaramond-Italic.ttf);
     font-weight: 400;
     font-style: italic;
 }
 @font-face {
     font-family: "Cormorant Garamond";
-    src: url(fonts/CormorantGaramond-Medium.ttf);
+    src: url(../fonts/CormorantGaramond-Medium.ttf);
     font-weight: 500;
 }
 @font-face {
     font-family: "Cormorant Garamond";
-    src: url(fonts/CormorantGaramond-MediumItalic.ttf);
+    src: url(../fonts/CormorantGaramond-MediumItalic.ttf);
     font-weight: 500;
     font-style: italic;
 }
 @font-face {
     font-family: "Cormorant Garamond";
-    src: url(fonts/CormorantGaramond-Semibold.ttf);
+    src: url(../fonts/CormorantGaramond-Semibold.ttf);
     font-weight: 600;
 }
 @font-face {
     font-family: "Cormorant Garamond";
-    src: url(fonts/CormorantGaramond-SemiboldItalic.ttf);
+    src: url(../fonts/CormorantGaramond-SemiboldItalic.ttf);
     font-weight: 600;
     font-style: italic;
 }
 @font-face {
     font-family: "Cormorant Garamond";
-    src: url(fonts/CormorantGaramond-Bold.ttf);
+    src: url(../fonts/CormorantGaramond-Bold.ttf);
     font-weight: 700;
 }
 @font-face {
     font-family: "Cormorant Garamond";
-    src: url(fonts/CormorantGaramond-BoldItalic.ttf);
+    src: url(../fonts/CormorantGaramond-BoldItalic.ttf);
     font-weight: 700;
     font-style: italic;
 }

--- a/_themes/classic/css/_sass/partials/fonts/_crimson-text.scss
+++ b/_themes/classic/css/_sass/partials/fonts/_crimson-text.scss
@@ -1,32 +1,32 @@
 // Crimson Text 
 @font-face {
     font-family: "Crimson Text";
-    src: url(fonts/CrimsonText-Roman.ttf);
+    src: url(../fonts/CrimsonText-Roman.ttf);
 }
 @font-face {
     font-family: "Crimson Text";
-    src: url(fonts/CrimsonText-Italic.ttf);
+    src: url(../fonts/CrimsonText-Italic.ttf);
 	font-style: italic;
 }
 @font-face {
     font-family: "Crimson Text";
-    src: url(fonts/CrimsonText-Bold.ttf);
+    src: url(../fonts/CrimsonText-Bold.ttf);
 	font-weight: bold;
 }
 @font-face {
     font-family: "Crimson Text";
-    src: url(fonts/CrimsonText-BoldItalic.ttf);
+    src: url(../fonts/CrimsonText-BoldItalic.ttf);
 	font-weight: bold;
 	font-style: italic;
 }
 @font-face {
     font-family: "Crimson Text";
-    src: url(fonts/CrimsonText-Semibold.ttf);
+    src: url(../fonts/CrimsonText-Semibold.ttf);
     font-weight: 600;
 }
 @font-face {
     font-family: "Crimson Text";
-    src: url(fonts/CrimsonText-SemiboldItalic.ttf);
+    src: url(../fonts/CrimsonText-SemiboldItalic.ttf);
     font-weight: 600;
     font-style: italic;
 }

--- a/_themes/classic/css/_sass/partials/fonts/_crimson.scss
+++ b/_themes/classic/css/_sass/partials/fonts/_crimson.scss
@@ -1,32 +1,32 @@
 // Crimson https://github.com/skosch/Crimson
 @font-face {
     font-family: "Crimson";
-    src: url(fonts/Crimson-Roman.otf);
+    src: url(../fonts/Crimson-Roman.otf);
 }
 @font-face {
     font-family: "Crimson";
-    src: url(fonts/Crimson-Italic.otf);
+    src: url(../fonts/Crimson-Italic.otf);
 	font-style: italic;
 }
 @font-face {
     font-family: "Crimson";
-    src: url(fonts/Crimson-Bold.otf);
+    src: url(../fonts/Crimson-Bold.otf);
 	font-weight: bold;
 }
 @font-face {
     font-family: "Crimson";
-    src: url(fonts/Crimson-BoldItalic.otf);
+    src: url(../fonts/Crimson-BoldItalic.otf);
 	font-weight: bold;
 	font-style: italic;
 }
 @font-face {
     font-family: "Crimson";
-    src: url(fonts/Crimson-Semibold.otf);
+    src: url(../fonts/Crimson-Semibold.otf);
     font-weight: 600;
 }
 @font-face {
     font-family: "Crimson";
-    src: url(fonts/Crimson-SemiboldItalic.otf);
+    src: url(../fonts/Crimson-SemiboldItalic.otf);
     font-weight: 600;
     font-style: italic;
 }

--- a/_themes/classic/css/_sass/partials/fonts/_inconsolata.scss
+++ b/_themes/classic/css/_sass/partials/fonts/_inconsolata.scss
@@ -1,4 +1,4 @@
 @font-face {
     font-family: "Inconsolata", monospace;
-    src: url(fonts/Inconsolata-Regular.ttf);
+    src: url(../fonts/Inconsolata-Regular.ttf);
 }

--- a/_themes/classic/css/_sass/partials/fonts/_kalam.scss
+++ b/_themes/classic/css/_sass/partials/fonts/_kalam.scss
@@ -1,15 +1,15 @@
 // Kalam (Google Fonts)
 @font-face {
     font-family: "Kalam";
-    src: url(fonts/Kalam-Regular.ttf);
+    src: url(../fonts/Kalam-Regular.ttf);
 }
 @font-face {
     font-family: "Kalam";
-    src: url(fonts/Kalam-Light.ttf);
+    src: url(../fonts/Kalam-Light.ttf);
 	font-weight: 300;
 }
 @font-face {
     font-family: "Kalam";
-    src: url(fonts/Kalam-Bold.ttf);
+    src: url(../fonts/Kalam-Bold.ttf);
 	font-weight: bold;
 }

--- a/_themes/classic/css/_sass/partials/fonts/_libre-baskerville.scss
+++ b/_themes/classic/css/_sass/partials/fonts/_libre-baskerville.scss
@@ -1,0 +1,15 @@
+// Libre Baskerville https://www.google.com/fonts/specimen/Libre+Baskerville
+@font-face {
+    font-family: "Libre Baskerville";
+    src: url(../fonts/LibreBaskerville-Regular.ttf);
+}
+@font-face {
+    font-family: "Libre Baskerville";
+    src: url(../fonts/LibreBaskerville-Bold.ttf);
+    font-weight: bold;
+}
+@font-face {
+    font-family: "Libre Baskerville";
+    src: url(../fonts/LibreBaskerville-Italic.ttf);
+    font-style: italic;
+}

--- a/_themes/classic/css/_sass/partials/fonts/_linux-biolinum.scss
+++ b/_themes/classic/css/_sass/partials/fonts/_linux-biolinum.scss
@@ -1,15 +1,15 @@
 // Linux Biolinum
 @font-face {
     font-family: "Linux Biolinum";
-    src: url(fonts/LinBiolinum_R.otf);
+    src: url(../fonts/LinBiolinum_R.otf);
 }
 @font-face {
     font-family: "Linux Biolinum";
-    src: url(fonts/LinBiolinum_RB.otf);
+    src: url(../fonts/LinBiolinum_RB.otf);
 	font-weight: bold;
 }
 @font-face {
     font-family: "Linux Biolinum";
-    src: url(fonts/LinBiolinum_RI.otf);
+    src: url(../fonts/LinBiolinum_RI.otf);
 	font-style: italic;
 }

--- a/_themes/classic/css/_sass/partials/fonts/_linux-libertine.scss
+++ b/_themes/classic/css/_sass/partials/fonts/_linux-libertine.scss
@@ -1,20 +1,20 @@
 @font-face {
     font-family: "Linux Libertine";
-    src: url(fonts/LinLibertine_R.otf);
+    src: url(../fonts/LinLibertine_R.otf);
 }
 @font-face {
     font-family: "Linux Libertine";
-    src: url(fonts/LinLibertine_RI.otf);
+    src: url(../fonts/LinLibertine_RI.otf);
 	font-style: italic;
 }
 @font-face {
     font-family: "Linux Libertine";
-    src: url(fonts/LinLibertine_RB.otf);
+    src: url(../fonts/LinLibertine_RB.otf);
 	font-weight: bold;
 }
 @font-face {
     font-family: "Linux Libertine";
-    src: url(fonts/LinLibertine_RBI.otf);
+    src: url(../fonts/LinLibertine_RBI.otf);
 	font-style: italic;
 	font-weight: bold;
 }

--- a/_themes/classic/css/_sass/partials/fonts/_montserrat.scss
+++ b/_themes/classic/css/_sass/partials/fonts/_montserrat.scss
@@ -1,10 +1,10 @@
 // Montserrat https://www.google.com/fonts/specimen/Montserrat
 @font-face {
     font-family: "Montserrat";
-    src: url(fonts/Montserrat-Regular.ttf);
+    src: url(../fonts/Montserrat-Regular.ttf);
 }
 @font-face {
     font-family: "Montserrat";
-    src: url(fonts/Montserrat-Bold.ttf);
+    src: url(../fonts/Montserrat-Bold.ttf);
 	font-weight: bold;
 }

--- a/_themes/classic/css/_sass/partials/fonts/_oswald.scss
+++ b/_themes/classic/css/_sass/partials/fonts/_oswald.scss
@@ -1,0 +1,15 @@
+// Oswald: https://fonts.google.com/specimen/Oswald
+@font-face {
+    font-family: "Oswald";
+    src: url(../fonts/Oswald-Regular.ttf);
+}
+@font-face {
+    font-family: "Oswald";
+    src: url(../fonts/Oswald-Light.ttf);
+    font-weight: 300;
+}
+@font-face {
+    font-family: "Oswald";
+    src: url(../fonts/Oswald-Bold.ttf);
+    font-weight: bold;
+}

--- a/_themes/classic/css/_sass/partials/fonts/_overpass.scss
+++ b/_themes/classic/css/_sass/partials/fonts/_overpass.scss
@@ -1,43 +1,43 @@
 // Overpass http://overpassfont.org/
 @font-face {
     font-family: "Overpass";
-    src: url(fonts/Overpass-Regular.ttf);
+    src: url(../fonts/Overpass-Regular.ttf);
 }
 @font-face {
     font-family: "Overpass";
-    src: url(fonts/Overpass-Bold.ttf);
+    src: url(../fonts/Overpass-Bold.ttf);
 	font-weight: bold;
 }
 @font-face {
     font-family: "Overpass";
-    src: url(fonts/Overpass-Regular-Italic.ttf);
+    src: url(../fonts/Overpass-Regular-Italic.ttf);
 	font-style: italic;
 }
 @font-face {
     font-family: "Overpass";
-    src: url(fonts/Overpass-Bold-Italic.ttf);
+    src: url(../fonts/Overpass-Bold-Italic.ttf);
 	font-weight: bold;
 	font-style: italic;
 }
 @font-face {
     font-family: "Overpass";
-    src: url(fonts/Overpass-Light.ttf);
+    src: url(../fonts/Overpass-Light.ttf);
     font-weight: 300;
 }
 @font-face {
     font-family: "Overpass";
-    src: url(fonts/Overpass-Light-Italic.ttf);
+    src: url(../fonts/Overpass-Light-Italic.ttf);
     font-weight: 300;
     font-style: italic;
 }
 @font-face {
     font-family: "Overpass";
-    src: url(fonts/Overpass-ExtraLight.ttf);
+    src: url(../fonts/Overpass-ExtraLight.ttf);
     font-weight: 200;
 }
 @font-face {
     font-family: "Overpass";
-    src: url(fonts/Overpass-ExtraLight-Italic.ttf);
+    src: url(../fonts/Overpass-ExtraLight-Italic.ttf);
     font-weight: 200;
     font-style: italic;
 }

--- a/_themes/classic/css/_sass/partials/fonts/_roboto.scss
+++ b/_themes/classic/css/_sass/partials/fonts/_roboto.scss
@@ -1,0 +1,67 @@
+// Roboto https://www.google.com/fonts/specimen/Roboto
+@font-face {
+    font-family: "Roboto";
+    src: url(../fonts/Roboto-Black.ttf);
+    font-weight: 900;
+}
+@font-face {
+    font-family: "Roboto";
+    src: url(../fonts/Roboto-BlackItalic.ttf);
+    font-weight: 900;
+    font-style: italic;
+}
+@font-face {
+    font-family: "Roboto";
+    src: url(../fonts/Roboto-Bold.ttf);
+    font-weight: 700;
+}
+@font-face {
+    font-family: "Roboto";
+    src: url(../fonts/Roboto-BoldItalic.ttf);
+    font-weight: 700;
+    font-style: italic;
+}
+@font-face {
+    font-family: "Roboto";
+    src: url(../fonts/Roboto-Italic.ttf);
+    font-weight: 400;
+    font-style: italic;
+}
+@font-face {
+    font-family: "Roboto";
+    src: url(../fonts/Roboto-Light.ttf);
+    font-weight: 300;
+}
+@font-face {
+    font-family: "Roboto";
+    src: url(../fonts/Roboto-LightItalic.ttf);
+    font-weight: 300;
+    font-style: italic;
+}
+@font-face {
+    font-family: "Roboto";
+    src: url(../fonts/Roboto-Medium.ttf);
+    font-weight: 600;
+}
+@font-face {
+    font-family: "Roboto";
+    src: url(../fonts/Roboto-MediumItalic.ttf);
+    font-weight: 600;
+    font-style: italic;
+}
+@font-face {
+    font-family: "Roboto";
+    src: url(../fonts/Roboto-Regular.ttf);
+    font-weight: 400;
+}
+@font-face {
+    font-family: "Roboto";
+    src: url(../fonts/Roboto-Thin.ttf);
+    font-weight: 200;
+}
+@font-face {
+    font-family: "Roboto";
+    src: url(../fonts/Roboto-ThinItalic.ttf);
+    font-weight: 200;
+    font-style: italic;
+}

--- a/_themes/classic/css/_sass/partials/fonts/_source-sans-pro.scss
+++ b/_themes/classic/css/_sass/partials/fonts/_source-sans-pro.scss
@@ -1,67 +1,67 @@
 // Source Sans Pro https://www.google.com/fonts/specimen/Source+Sans+Pro
 @font-face {
     font-family: "Source Sans Pro";
-    src: url(fonts/SourceSansPro-Black.ttf);
+    src: url(../fonts/SourceSansPro-Black.ttf);
 	font-weight: 900;
 }
 @font-face {
     font-family: "Source Sans Pro";
-    src: url(fonts/SourceSansPro-BlackItalic.ttf);
+    src: url(../fonts/SourceSansPro-BlackItalic.ttf);
 	font-weight: 900;
 	font-style: italic;
 }
 @font-face {
     font-family: "Source Sans Pro";
-    src: url(fonts/SourceSansPro-Bold.ttf);
+    src: url(../fonts/SourceSansPro-Bold.ttf);
 	font-weight: 700;
 }
 @font-face {
     font-family: "Source Sans Pro";
-    src: url(fonts/SourceSansPro-BoldItalic.ttf);
+    src: url(../fonts/SourceSansPro-BoldItalic.ttf);
 	font-weight: 700;
 	font-style: italic;
 }
 @font-face {
     font-family: "Source Sans Pro";
-    src: url(fonts/SourceSansPro-ExtraLight.ttf);
+    src: url(../fonts/SourceSansPro-ExtraLight.ttf);
 	font-weight: 200;
 }
 @font-face {
     font-family: "Source Sans Pro";
-    src: url(fonts/SourceSansPro-ExtraLightItalic.ttf);
+    src: url(../fonts/SourceSansPro-ExtraLightItalic.ttf);
 	font-weight: 200;
 	font-style: italic;
 }
 @font-face {
     font-family: "Source Sans Pro";
-    src: url(fonts/SourceSansPro-Italic.ttf);
+    src: url(../fonts/SourceSansPro-Italic.ttf);
 	font-weight: 400;
 	font-style: italic;
 }
 @font-face {
     font-family: "Source Sans Pro";
-    src: url(fonts/SourceSansPro-Light.ttf);
+    src: url(../fonts/SourceSansPro-Light.ttf);
 	font-weight: 300;
 }
 @font-face {
     font-family: "Source Sans Pro";
-    src: url(fonts/SourceSansPro-LightItalic.ttf);
+    src: url(../fonts/SourceSansPro-LightItalic.ttf);
 	font-weight: 300;
 	font-style: italic;
 }
 @font-face {
     font-family: "Source Sans Pro";
-    src: url(fonts/SourceSansPro-Regular.ttf);
+    src: url(../fonts/SourceSansPro-Regular.ttf);
 	font-weight: 400;
 }
 @font-face {
     font-family: "Source Sans Pro";
-    src: url(fonts/SourceSansPro-Semibold.ttf);
+    src: url(../fonts/SourceSansPro-Semibold.ttf);
 	font-weight: 600;
 }
 @font-face {
     font-family: "Source Sans Pro";
-    src: url(fonts/SourceSansPro-SemiboldItalic.ttf);
+    src: url(../fonts/SourceSansPro-SemiboldItalic.ttf);
 	font-weight: 600;
 	font-style: italic;
 }

--- a/_themes/classic/css/_sass/partials/fonts/_trajan-pro.scss
+++ b/_themes/classic/css/_sass/partials/fonts/_trajan-pro.scss
@@ -1,10 +1,10 @@
 // Trajan Pro
 @font-face {
     font-family: "Trajan Pro";
-    src: url(fonts/TrajanPro-Regular.otf);
+    src: url(../fonts/TrajanPro-Regular.otf);
 }
 @font-face {
     font-family: "Trajan Pro";
-    src: url(fonts/TrajanPro-Bold.otf);
+    src: url(../fonts/TrajanPro-Bold.otf);
 	font-weight: bold;
 }


### PR DESCRIPTION
Changelog: v0.2.3
- Fix broken pink to print stylesheets.
- Fix broken links in @font-face partials.
- Add more font includes.
- Turn on kramdown auto_id_stripping to keep IDs neat and persistent, and ahead of 2.0 where this will be default.
- Fix line-height on chapter-numbers to retain baseline grid.
